### PR TITLE
KUVA-418 | Add support for basic internationalization

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,7 @@
     "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:import/errors",
     "plugin:import/warnings",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Development pipeline (eslint, prettier, storybook, jest, travis, rollup)
 - Publish pipeline
 - Initial form elements
+- Support for basic internationalization

--- a/README.md
+++ b/README.md
@@ -29,3 +29,33 @@ A new version of the `npm` package is automatically released when a new release 
 
 - This component uses `hds-react`, which injects some global styles for instance for headings. Be mindful of this if your application does not already use HDS. [174](https://github.com/City-of-Helsinki/helsinki-design-system/issues/174)
 - This component does not inject the Helsinki Grotesk font for you--you must add it yourself.
+
+## Module API
+
+### `FeedbackForm`
+
+**Props**
+
+| Prop        | Description                                                                                                                                                                                      | Default           |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------- |
+| `locale`    | Controls the current language of the component.                                                                                                                                                  |                   |
+| `messages?` | Controls the messages that are used for translations.                                                                                                                                            | `defaultMessages` |
+| `fluid?`    | By default the component has a max width set in accordance with HDS. If you want to ignore it, you can set this option to true, in which case the form will span with no `max-width` limitation. | `false`           |
+
+### `defaultMessages`
+
+The set of translations that the `FeedbackForm` component uses by default.
+
+## Internationalization
+
+The `FeedbackForm` component is internationalized into three locales by default: `fi`, `sv` and `en`.
+
+The component requires its consumer to provide the current locale as in most cases trying to infer it automatically would be doing something the consuming application has already done.
+
+### Changing translation content
+
+If some of the default translations do not suit your needs, you can always overwrite the defaults by using `FeedbackForm`'s `messages` prop. I recommend that you import `defaultMessages` from this package and use it as a basis for your new translations.
+
+### Adding new locales
+
+You can add new locales by overriding the default messages by using `FeedbackForm`'s `messages` prop. I recommend that you import `defaultMessages` from this package and extend it with your new locale. After the new locale is added, you can toggle the component to use it by simply changing the `locale` prop into that locale.

--- a/jest.config.js
+++ b/jest.config.js
@@ -150,9 +150,7 @@ module.exports = {
   // ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  // testPathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  testPathIgnorePatterns: ["lib/", "lib-esm/"],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
   // testRegex: [],

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@storybook/react": "^6.0.0-beta.38",
     "@testing-library/react": "^10.4.3",
     "@types/jest": "^26.0.3",
+    "@types/lodash.get": "^4.4.6",
     "@types/react": "^16.9.41",
     "@types/react-dom": "^16.9.8",
     "@typescript-eslint/eslint-plugin": "^3.5.0",
@@ -76,6 +77,7 @@
   },
   "dependencies": {
     "hds-design-tokens": "^0.11.3",
-    "hds-react": "^0.11.3"
+    "hds-react": "^0.11.3",
+    "lodash.get": "^4.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@babel/core": "^7.10.4",
     "@rollup/plugin-babel": "^5.0.4",
     "@rollup/plugin-commonjs": "^13.0.0",
+    "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^8.1.0",
     "@storybook/addon-a11y": "^6.0.0-beta.38",
     "@storybook/addon-actions": "^6.0.0-beta.38",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -51,5 +51,6 @@ export default {
     "react-spring/renderprops.cjs",
     "lodash.uniqueid",
     "lodash.isequal",
+    "lodash.get",
   ],
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,7 @@
 import babel from "@rollup/plugin-babel";
 import resolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
+import json from "@rollup/plugin-json";
 import includePaths from "rollup-plugin-includepaths";
 import postcss from "rollup-plugin-postcss";
 import typescript from "rollup-plugin-typescript2";
@@ -26,6 +27,7 @@ export default {
     commonjs({
       include: "../../node_modules/**",
     }),
+    json(),
     postcss({
       modules: true,
       minimize: {

--- a/src/common/hooks/useTranslation.tsx
+++ b/src/common/hooks/useTranslation.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import get from "lodash.get";
+
+import { Messages } from "../../domain/i18n/types";
+
+interface Props {
+  currentLocale: string;
+  messages: Messages;
+}
+
+function useTranslation({ currentLocale, messages }: Props) {
+  const t = React.useCallback(
+    (stringPath: string): string | null => {
+      return get(messages, `${currentLocale}.${stringPath}`, null);
+    },
+    [currentLocale, messages]
+  );
+
+  return [t];
+}
+
+export default useTranslation;

--- a/src/domain/feedbackForm/FeedbackForm.stories.tsx
+++ b/src/domain/feedbackForm/FeedbackForm.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { withKnobs } from "@storybook/addon-knobs";
+import { withKnobs, select } from "@storybook/addon-knobs";
 import {
   Props,
   Stories,
@@ -30,10 +30,21 @@ export default {
   },
 };
 
-export const Default = () => <FeedbackForm />;
+export const Default = () => <FeedbackForm locale="fi" />;
 
 export const Playground = () => {
-  return <FeedbackForm />;
+  const locale = select(
+    "Locale",
+    {
+      Undefined: undefined,
+      Finnish: "fi",
+      Swedish: "sv",
+      English: "en",
+    },
+    undefined
+  );
+
+  return <FeedbackForm locale={locale} />;
 };
 
 Playground.story = {

--- a/src/domain/feedbackForm/FeedbackForm.stories.tsx
+++ b/src/domain/feedbackForm/FeedbackForm.stories.tsx
@@ -36,12 +36,11 @@ export const Playground = () => {
   const locale = select(
     "Locale",
     {
-      Undefined: undefined,
       Finnish: "fi",
       Swedish: "sv",
       English: "en",
     },
-    undefined
+    "fi"
   );
 
   return <FeedbackForm locale={locale} />;

--- a/src/domain/feedbackForm/FeedbackForm.tsx
+++ b/src/domain/feedbackForm/FeedbackForm.tsx
@@ -1,16 +1,26 @@
 import React from "react";
 import { TextInput, TextArea, Checkbox, Button, IconUpload } from "hds-react";
 
+import useTranslation from "../../common/hooks/useTranslation";
 import A from "../../common/components/a/A";
 import PlainList from "../../common/components/plainList/PlainList";
 import Text from "../../common/components/text/Text";
+import { Messages } from "../i18n/types";
+import defaultMessages from "../i18n/defaultMessages";
 import styles from "./feedbackForm.module.scss";
 
 interface Props {
   fluid?: boolean;
+  messages?: Messages;
+  locale: string;
 }
 
-function FeedbackForm({ fluid = false }: Props) {
+function FeedbackForm({
+  fluid = false,
+  locale,
+  messages = defaultMessages,
+}: Props) {
+  const [t] = useTranslation({ currentLocale: locale, messages });
   const [showContactDetailFields, setShowContactDetailFields] = React.useState(
     false
   );
@@ -28,28 +38,25 @@ function FeedbackForm({ fluid = false }: Props) {
         .join(" ")}
     >
       <div className={styles.feedbackFormSection}>
-        <Text variant="h1">Anna palautetta</Text>
-        <Text>
-          Anna palautetta verkkopalvelumme toiminnasta. Pyrimme vastaamaan
-          viiden arkipäivän kuluessa. Voit lähettää viestisi nimettömänä. Jos
-          haluat henkilökohtaisen vastauksen, jätä yhteistietosi.
-        </Text>
+        <Text variant="h1">{t("formTitle")}</Text>
+        <Text>{t("formDescription")}</Text>
       </div>
       <section className={styles.feedbackFormSection}>
-        <Text variant="h2">Palaute</Text>
+        <Text variant="h2">{t("feedbackSectionTitle")}</Text>
         <div className={styles.feedbackFormControlGrid}>
-          <TextInput name="title" id="title" labelText="Otsikko" />
-          <TextArea name="content" id="content" labelText="Palaute *" />
+          <TextInput name="title" id="title" labelText={t("titleFieldLabel")} />
+          <TextArea
+            name="content"
+            id="content"
+            labelText={`${t("contentFieldLabel")} *`}
+          />
         </div>
       </section>
       <section className={styles.feedbackFormSection}>
-        <Text variant="h2">Lisää liitetiedosto</Text>
-        <Text>
-          Voit lisätä halutessasi lisätä palautteeseen liitetiedoston,
-          tiedostonjen maksimikoko on 5M
-        </Text>
+        <Text variant="h2">{t("attachmentsSectionTitle")}</Text>
+        <Text>{t("attachmentsSectionDescription")}</Text>
         <Button variant="secondary" iconLeft={<IconUpload />}>
-          Lisää tiedosto
+          {t("doAddFile")}
         </Button>
       </section>
       <div className={styles.feedbackFormSection}>
@@ -58,64 +65,50 @@ function FeedbackForm({ fluid = false }: Props) {
           id="want-reply"
           checked={wantReplyValue}
           onChange={handleWantReplyToggle}
-          labelText="Haluan vastauksen palautteeseeni"
+          labelText={t("userWillsReplyLabel")}
         />
       </div>
       {showContactDetailFields && (
         <section className={styles.feedbackFormSection}>
-          <Text variant="h2">Yhteystietosi</Text>
+          <Text variant="h2">{t("contactDetailsSectionTitle")}</Text>
           <div className={styles.feedbackFormControlGrid}>
             <TextInput
               name="user-name"
               id="user-name"
-              labelText="Nimi tai nimimerkki"
+              labelText={t("userNameFieldLabel")}
             />
             <TextInput
               name="user-email"
               id="user-email"
-              labelText="Sähköpostiosoite"
+              labelText={t("userEmailFieldLabel")}
             />
           </div>
         </section>
       )}
       <div className={styles.feedbackFormSection}>
-        <Button type="submit">Lähetä palaute</Button>
+        <Button type="submit">{t("doSendFeedback")}</Button>
       </div>
       <div className={styles.feedbackFormSection}>
-        <Text>
-          Koska tämän palautelomakkeen tietoturvaa ei ole varmistettu,
-          palautteessanne ei ole syytä mainita esim. henkilötunnuksia,
-          pankkitilin numeroja tai varallisuutta koskevia tietoja eikä myöskään
-          arkaluontoisia tietoja kuten tietoja terveydentilasta tai asiakkuuteen
-          liittyviä tietoja
-        </Text>
-        <Text>
-          Sähköinen viesti toimitetaan viranomaiselle lähettäjän omalla
-          vastuulla (Laki sähköisestä asioinnista viranomaistoiminnassa
-          24.1.2003/13, 8 §). Jos asiakirjan toimittamiselle on asetettu
-          määräaika, lähettäjän on huolehdittava siitä, että asiakirja saapuu
-          viranomaiseen määräajassa (Hallintolaki 6.6.2003/434, 17 §).
-        </Text>
-        <Text>
-          Tämän vuoksi palauteviestinä ei tule lähettää esimerkiksi
-          lakisääteisiä muistutuksia, kanteluja tai oikaisuvaatimuksia
-          päätöksistä.
-        </Text>
+        {t("formPrivacyWarning")
+          .split("\n")
+          .map((paragraph) => (
+            <Text key={paragraph.slice(0, 8)}>{paragraph}</Text>
+          ))}
         <PlainList
           items={[
             <A
-              href="https://www.hel.fi/rekisteriseloste"
+              href={t("formPrivacyPolicyLink")}
               target="tab"
               variant="camouflaged"
             >
-              Palautejärjestelmän rekisteriseloste
+              {t("formPrivacyPolicyLabel")}
             </A>,
             <A
-              href="https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/osallistu-ja-vaikuta/palaute/ohjeita-palautteesta/"
+              href={t("formInstructionLink")}
               target="tab"
               variant="camouflaged"
             >
-              Tietoa palautteen antamisesta
+              {t("formInstructionLabel")}
             </A>,
           ]}
         />

--- a/src/domain/feedbackForm/__tests__/FeedbackForm.test.tsx
+++ b/src/domain/feedbackForm/__tests__/FeedbackForm.test.tsx
@@ -4,7 +4,7 @@ import { render, fireEvent } from "@testing-library/react";
 import FeedbackForm from "../FeedbackForm";
 
 describe("<FeedbackForm />", () => {
-  const getWrapper = () => render(<FeedbackForm />);
+  const getWrapper = () => render(<FeedbackForm locale="fi" />);
 
   it("user can input expected information", () => {
     const fields = [

--- a/src/domain/i18n/defaultMessages.ts
+++ b/src/domain/i18n/defaultMessages.ts
@@ -1,0 +1,12 @@
+import { Messages } from "./types";
+import fiMessages from "./fiMessages.json";
+import svMessages from "./svMessages.json";
+import enMessages from "./enMessages.json";
+
+const messages: Messages = {
+  fi: fiMessages,
+  sv: svMessages,
+  en: enMessages,
+};
+
+export default messages;

--- a/src/domain/i18n/enMessages.json
+++ b/src/domain/i18n/enMessages.json
@@ -1,0 +1,20 @@
+{
+  "formTitle": "EN_formTitle",
+  "formDescription": "EN_formDescription",
+  "feedbackSectionTitle": "EN_feedbackSectionTitle",
+  "titleFieldLabel": "EN_titleFieldLabel",
+  "contentFieldLabel": "EN_contentFieldLabel",
+  "attachmentsSectionTitle": "EN_attachmentsSectionTitle",
+  "attachmentsSectionDescription": "EN_attachmentsSectionDescription",
+  "doAddFile": "EN_doAddFile",
+  "userWillsReplyLabel": "EN_userWillsReplyLabel",
+  "contactDetailsSectionTitle": "EN_contactDetailsSectionTitle",
+  "userNameFieldLabel": "EN_userNameFieldLabel",
+  "userEmailFieldLabel": "EN_userEmailFieldLabel",
+  "doSendFeedback": "EN_doSendFeedback",
+  "formPrivacyWarning": "EN_formPrivacyWarning",
+  "formPrivacyPolicyLink": "EN_formPrivacyPolicyLink",
+  "formPrivacyPolicyLabel": "EN_formPrivacyPolicyLabel",
+  "formInstructionLink": "EN_formInstructionLink",
+  "formInstructionLabel": "EN_formInstructionLabel"
+}

--- a/src/domain/i18n/fiMessages.json
+++ b/src/domain/i18n/fiMessages.json
@@ -1,0 +1,20 @@
+{
+  "formTitle": "Anna palautetta",
+  "formDescription": "Anna palautetta verkkopalvelumme toiminnasta. Pyrimme vastaamaan viiden arkipäivän kuluessa. Voit lähettää viestisi nimettömänä. Jos haluat henkilökohtaisen vastauksen, jätä yhteistietosi.",
+  "feedbackSectionTitle": "Palaute",
+  "titleFieldLabel": "Otsikko",
+  "contentFieldLabel": "Palaute",
+  "attachmentsSectionTitle": "Lisää liitetiedosto",
+  "attachmentsSectionDescription": "Voit lisätä halutessasi lisätä palautteeseen liitetiedoston, tiedostonjen maksimikoko on 5M",
+  "doAddFile": "Lisää tiedosto",
+  "userWillsReplyLabel": "Haluan vastauksen palautteeseeni",
+  "contactDetailsSectionTitle": "Yhteystietosi",
+  "userNameFieldLabel": "Nimi tai nimimerkki",
+  "userEmailFieldLabel": "Sähköpostiosoite",
+  "doSendFeedback": "Lähetä palaute",
+  "formPrivacyWarning": "Koska tämän palautelomakkeen tietoturvaa ei ole varmistettu, palautteessanne ei ole syytä mainita esim. henkilötunnuksia, pankkitilin numeroja tai varallisuutta koskevia tietoja eikä myöskään arkaluontoisia tietoja kuten tietoja terveydentilasta tai asiakkuuteen liittyviä tietoja\nSähköinen viesti toimitetaan viranomaiselle lähettäjän omalla vastuulla (Laki sähköisestä asioinnista viranomaistoiminnassa 24.1.2003/13, 8 §). Jos asiakirjan toimittamiselle on asetettu määräaika, lähettäjän on huolehdittava siitä, että asiakirja saapuu viranomaiseen määräajassa (Hallintolaki 6.6.2003/434, 17 §).\nTämän vuoksi palauteviestinä ei tule lähettää esimerkiksi lakisääteisiä muistutuksia, kanteluja tai oikaisuvaatimuksia päätöksistä.",
+  "formPrivacyPolicyLink": "https://www.hel.fi/rekisteriseloste",
+  "formPrivacyPolicyLabel": "Palautejärjestelmän rekisteriseloste",
+  "formInstructionLink": "https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/osallistu-ja-vaikuta/palaute/ohjeita-palautteesta/",
+  "formInstructionLabel": "Tietoa palautteen antamisesta"
+}

--- a/src/domain/i18n/svMessages.json
+++ b/src/domain/i18n/svMessages.json
@@ -1,0 +1,20 @@
+{
+  "formTitle": "SV_formTitle",
+  "formDescription": "SV_formDescription",
+  "feedbackSectionTitle": "SV_feedbackSectionTitle",
+  "titleFieldLabel": "SV_titleFieldLabel",
+  "contentFieldLabel": "SV_contentFieldLabel",
+  "attachmentsSectionTitle": "SV_attachmentsSectionTitle",
+  "attachmentsSectionDescription": "SV_attachmentsSectionDescription",
+  "doAddFile": "SV_doAddFile",
+  "userWillsReplyLabel": "SV_userWillsReplyLabel",
+  "contactDetailsSectionTitle": "SV_contactDetailsSectionTitle",
+  "userNameFieldLabel": "SV_userNameFieldLabel",
+  "userEmailFieldLabel": "SV_userEmailFieldLabel",
+  "doSendFeedback": "SV_doSendFeedback",
+  "formPrivacyWarning": "SV_formPrivacyWarning",
+  "formPrivacyPolicyLink": "SV_formPrivacyPolicyLink",
+  "formPrivacyPolicyLabel": "SV_formPrivacyPolicyLabel",
+  "formInstructionLink": "SV_formInstructionLink",
+  "formInstructionLabel": "SV_formInstructionLabel"
+}

--- a/src/domain/i18n/types.ts
+++ b/src/domain/i18n/types.ts
@@ -1,0 +1,22 @@
+type MessageSet = {
+  formTitle: string;
+  formDescription: string;
+  feedbackSectionTitle: string;
+  titleFieldLabel: string;
+  contentFieldLabel: string;
+  attachmentsSectionTitle: string;
+  attachmentsSectionDescription: string;
+  doAddFile: string;
+  userWillsReplyLabel: string;
+  contactDetailsSectionTitle: string;
+  userNameFieldLabel: string;
+  userEmailFieldLabel: string;
+  doSendFeedback: string;
+  formPrivacyWarning: string;
+  formPrivacyPolicyLink: string;
+  formPrivacyPolicyLabel: string;
+  formInstructionLink: string;
+  formInstructionLabel: string;
+};
+
+export type Messages = Record<string, MessageSet>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./domain/feedbackForm/FeedbackForm";
+export { default as defaultMessages } from "./domain/i18n/defaultMessages";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "sourceMap": true,
     "declaration": true,
     "esModuleInterop": true,
-    "jsx": "react"
+    "jsx": "react",
+    "resolveJsonModule": true
   },
   "include": ["src", ".storybook"],
   "compileOnSave": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1839,6 +1839,13 @@
     magic-string "^0.25.2"
     resolve "^1.11.0"
 
+"@rollup/plugin-json@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-json/-/plugin-json-4.1.0.tgz#54e09867ae6963c593844d8bd7a9c718294496f3"
+  integrity sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==
+  dependencies:
+    "@rollup/pluginutils" "^3.0.8"
+
 "@rollup/plugin-node-resolve@^8.1.0":
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-8.1.0.tgz#1da5f3d0ccabc8f66f5e3c74462aad76cfd96c47"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2832,6 +2832,18 @@
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/lodash.get@^4.4.6":
+  version "4.4.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.get/-/lodash.get-4.4.6.tgz#0c7ac56243dae0f9f09ab6f75b29471e2e777240"
+  integrity sha512-E6zzjR3GtNig8UJG/yodBeJeIOtgPkMgsLjDU3CbgCAPC++vJ0eCMnJhVpRZb/ENqEFlov1+3K9TKtY4UdWKtQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.157"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.157.tgz#fdac1c52448861dfde1a2e1515dbc46e54926dc8"
+  integrity sha512-Ft5BNFmv2pHDgxV5JDsndOWTRJ+56zte0ZpYLowp03tW+K+t8u8YMOzAnpuqPgzX6WO1XpDIUm7u04M8vdDiVQ==
+
 "@types/markdown-to-jsx@^6.11.0":
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/@types/markdown-to-jsx/-/markdown-to-jsx-6.11.0.tgz#a19e458a9415763859f2c92c4c5b07a80bea8c14"
@@ -10591,6 +10603,11 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
 lodash.isequal@4.5.0:
   version "4.5.0"


### PR DESCRIPTION
## Description

Adds support to three locales by default (some translations pending): `fi`, `sv` and `en`. Translations are implemented with a simple custom hook in order to avoid unduly powerful (and large) dependencies.

## Motivation and Context

All (most) of our application can be used in three different languages. Supporting these out of the box makes the development experience smoother which will likely translate into a better UX for the users as well. For cases where the translations need to be changed or a new locale has to be added, support is also provided.

## How Has This Been Tested?

I added a knob into the storybook environment which allows for manual testing.

## Screenshots (if appropriate):

<img width="1196" alt="Screenshot 2020-07-03 at 16 08 10" src="https://user-images.githubusercontent.com/9090689/86472171-6ac75f00-bd47-11ea-84ef-4a1b403be198.png">

