### PR TITLE
Fix double click on file upload button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 - Deprecate fluid prop (consumers can attain same results by using a theme)
+
+### Fixed
+
+- Double clicks on file upload

--- a/src/common/components/fileUploadField/FileUploadField.tsx
+++ b/src/common/components/fileUploadField/FileUploadField.tsx
@@ -75,7 +75,6 @@ function FileUploadField({
       <label htmlFor={id}>
         <Button
           aria-controls={id}
-          onClick={handleBeginFileSelect}
           onKeyPress={handleButtonEmulation}
           onKeyUp={handleButtonEmulation}
         >

--- a/src/domain/feedbackForm/types.ts
+++ b/src/domain/feedbackForm/types.ts
@@ -18,7 +18,6 @@ export interface FormValues {
 
 export type ButtonAddFilesProps = {
   children: ReactNode;
-  onClick: ReactEventHandler<HTMLSpanElement>;
   onKeyPress: (e: KeyboardEvent<HTMLSpanElement>) => void;
   onKeyUp: (e: KeyboardEvent<HTMLSpanElement>) => void;
 };


### PR DESCRIPTION
## Description

The "span button" had an unneeded `onClick` handler. The wrapping `label` already manages the click action.
