### PR TITLE
KUVA-423 | Add configuration for including fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Ability to theme component
 - Support for file upload
 - Mandatory service request type field
+- Configuration for including fields
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ A new version of the `npm` package is automatically released when a new release 
 | `backendConfig?` | The component provides a default backend that integrates it into Helsinki's Open311 based feedback system. If you want to use it, you have to provide this configuration object. You can find an example from storybook.               |                   |
 | `onSubmit?`      | If you do not want to use the default backend, you can use a custom one by providing `onSubmit`.                                                                                                                                       |                   |
 | `theme?`         | By default this component is themed to match with HDS. If you do not want that, or you need to tweak the component due to some other reason, you can do it by providing a theme. You can use the `hdsTheme` as a basis for your tweak. | `hdsTheme`        |
+| `include?`         | Control which fields you want to include into the form. | `all fields`        |
+| `exclude?`         | Control fields that are excluded from the form. Fields are first included and then excluded. If you include and exclude the same field, it will be excluded. | `[]`        |
 
 ### `defaultMessages`
 

--- a/src/domain/feedbackComponent/FeedbackComponent.stories.tsx
+++ b/src/domain/feedbackComponent/FeedbackComponent.stories.tsx
@@ -1,5 +1,10 @@
 import React from "react";
-import { withKnobs, select, object } from "@storybook/addon-knobs";
+import {
+  withKnobs,
+  select,
+  object,
+  optionsKnob as option,
+} from "@storybook/addon-knobs";
 import {
   Props,
   Stories,
@@ -9,6 +14,8 @@ import {
 import { action } from "@storybook/addon-actions";
 
 import hdsTheme from "../hdsTheme/hdsTheme";
+import defaultInitialValues from "../feedbackForm/defaultInitialValues";
+import { FormFields } from "../feedbackForm/types";
 import FeedbackComponent from "./FeedbackComponent";
 
 // Sourced from https://dev.hel.fi/open311-test/v1/discovery.json
@@ -111,6 +118,14 @@ const themes = {
   custom: customTheme,
 };
 
+const fieldOptions = Object.keys(defaultInitialValues).reduce(
+  (obj, key) => ({
+    ...obj,
+    [key]: key,
+  }),
+  {}
+);
+
 export const Playground = () => {
   const locale = select(
     "Locale",
@@ -129,12 +144,27 @@ export const Playground = () => {
     },
     "hds"
   );
+  const include = option<FormFields[]>(
+    "Include",
+    fieldOptions,
+    Object.keys(fieldOptions) as FormFields[],
+    {
+      display: "multi-select",
+    }
+  );
+  const exclude = option<FormFields[]>("Exclude", fieldOptions, [], {
+    display: "multi-select",
+  });
+  const initialValues = object("Initial values", {});
 
   return (
     <FeedbackComponent
       locale={locale}
       onSubmit={() => Promise.resolve()}
       theme={themes[theme]}
+      include={include || []}
+      exclude={exclude || []}
+      initialValues={initialValues}
     />
   );
 };

--- a/src/domain/feedbackForm/FeedbackForm.tsx
+++ b/src/domain/feedbackForm/FeedbackForm.tsx
@@ -7,20 +7,43 @@ import Dropdown from "../../common/components/formikWrappers/Dropdown";
 import defaultInitialValues from "./defaultInitialValues";
 import useTranslation from "../i18n/useTranslation";
 import hdsTheme from "../hdsTheme/hdsTheme";
-import { FormValues, FormTheme } from "./types";
+import { FormValues, FormTheme, FormFields } from "./types";
 import schema from "./schema";
 import { ServiceRequestTypes } from "./constants";
+
+function assertFieldsConfigurations(
+  excludedFields: FormFields[],
+  initialValues: FormValues
+) {
+  excludedFields.forEach((field) => {
+    const value = initialValues[field];
+    const isNotValid = schema.fields[field].isValid(value);
+
+    if (isNotValid) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `You have toggled off the ${field} field and not provided a valid default value for it. This means the user won't ever be able to submit the form successfully.`
+      );
+    }
+  });
+}
 
 export interface Props {
   initialValues?: Partial<FormValues>;
   onSubmit: (values: FormValues) => Promise<unknown>;
   theme?: FormTheme;
+  include?: FormFields[];
+  exclude?: FormFields[];
 }
+
+const allKeys: FormFields[] = Object.keys(defaultInitialValues) as FormFields[];
 
 function FeedbackForm({
   initialValues: externalInitialValues,
   onSubmit,
   theme: Theme = hdsTheme,
+  include = allKeys,
+  exclude = [],
 }: Props) {
   const [t] = useTranslation();
   const [showContactDetailFields, setShowContactDetailFields] = React.useState(
@@ -35,6 +58,20 @@ function FeedbackForm({
     ...defaultInitialValues,
     ...externalInitialValues,
   };
+  const formsFieldsInUse = include.filter(
+    (includedField) => !exclude.includes(includedField)
+  );
+
+  const getIsFieldUsed = (...fields: FormFields[]): boolean => {
+    return fields.reduce(
+      (acc, field) => acc || formsFieldsInUse.includes(field),
+      false
+    );
+  };
+
+  React.useEffect(() => {
+    assertFieldsConfigurations(exclude, initialValues);
+  }, [exclude, initialValues]);
 
   return (
     <Formik
@@ -72,114 +109,140 @@ function FeedbackForm({
                   <Theme.TextH1>{t("form.title")}</Theme.TextH1>
                   <Theme.TextP>{t("form.description")}</Theme.TextP>
                 </Theme.Section>
-                <Theme.LabeledSection>
-                  <Theme.TextH2>
-                    {t("form.section.feedback.title")}
-                  </Theme.TextH2>
-                  <Theme.FieldGrid>
-                    <Dropdown
-                      component={Theme.Dropdown}
-                      id="serviceRequestType"
-                      name="serviceRequestType"
-                      labelText={t("field.serviceRequestType.label")}
-                      required
-                      options={[
-                        {
-                          value: ServiceRequestTypes.Thank,
-                          label: t("field.serviceRequestType.option.thank"),
-                        },
-                        {
-                          value: ServiceRequestTypes.Blame,
-                          label: t("field.serviceRequestType.option.blame"),
-                        },
-                        {
-                          value: ServiceRequestTypes.Question,
-                          label: t("field.serviceRequestType.option.question"),
-                        },
-                        {
-                          value: ServiceRequestTypes.Idea,
-                          label: t("field.serviceRequestType.option.idea"),
-                        },
-                        {
-                          value: ServiceRequestTypes.Accessibility,
-                          label: t(
-                            "field.serviceRequestType.option.accessibility"
-                          ),
-                        },
-                        {
-                          value: ServiceRequestTypes.Other,
-                          label: t("field.serviceRequestType.option.other"),
-                        },
-                      ]}
-                    />
-                    <Input
-                      component={Theme.TextInput}
-                      name="title"
-                      id="title"
-                      labelText={t("field.title.label")}
-                    />
-                    <Input
-                      component={Theme.TextArea}
-                      name="description"
-                      id="description"
-                      labelText={`${t("field.description.label")}`}
-                      required
-                    />
-                  </Theme.FieldGrid>
-                </Theme.LabeledSection>
-                <Theme.LabeledSection>
-                  <Theme.TextH2>
-                    {t("form.section.attachments.title")}
-                  </Theme.TextH2>
-                  <Theme.TextP>
-                    {t("form.section.attachments.description")}
-                  </Theme.TextP>
-                  <FileUploadField
-                    name="media"
-                    id="media"
-                    labelText={t("field.firstName.label")}
-                    addFilesButtonLabel={t("field.media.doAddFiles")}
-                    removeFileButtonLabel={t("field.media.doRemoveFile")}
-                    addFilesButton={Theme.ButtonAddFiles}
-                    removeFileButton={Theme.ButtonRemoveFile}
-                    component={Theme.FileUploadField}
-                  />
-                </Theme.LabeledSection>
-                <Theme.Section>
-                  <Theme.Checkbox
-                    name="want-reply"
-                    id="want-reply"
-                    checked={showContactDetailFields}
-                    onChange={handleWantReplyToggle}
-                    labelText={t("form.toggle.wantReply")}
-                  />
-                </Theme.Section>
-                {showContactDetailFields && (
+                {getIsFieldUsed(
+                  "serviceRequestType",
+                  "title",
+                  "description"
+                ) && (
                   <Theme.LabeledSection>
                     <Theme.TextH2>
-                      {t("form.section.contactDetails.title")}
+                      {t("form.section.feedback.title")}
                     </Theme.TextH2>
                     <Theme.FieldGrid>
-                      <Input
-                        component={Theme.TextInput}
-                        name="firstName"
-                        id="firstName"
-                        labelText={t("field.firstName.label")}
-                      />
-                      <Input
-                        component={Theme.TextInput}
-                        name="lastName"
-                        id="lastName"
-                        labelText={t("field.lastName.label")}
-                      />
-                      <Input
-                        component={Theme.TextInput}
-                        name="email"
-                        id="email"
-                        labelText={t("field.email.label")}
-                      />
+                      {getIsFieldUsed("serviceRequestType") && (
+                        <Dropdown
+                          component={Theme.Dropdown}
+                          id="serviceRequestType"
+                          name="serviceRequestType"
+                          labelText={t("field.serviceRequestType.label")}
+                          required
+                          options={[
+                            {
+                              value: ServiceRequestTypes.Thank,
+                              label: t("field.serviceRequestType.option.thank"),
+                            },
+                            {
+                              value: ServiceRequestTypes.Blame,
+                              label: t("field.serviceRequestType.option.blame"),
+                            },
+                            {
+                              value: ServiceRequestTypes.Question,
+                              label: t(
+                                "field.serviceRequestType.option.question"
+                              ),
+                            },
+                            {
+                              value: ServiceRequestTypes.Idea,
+                              label: t("field.serviceRequestType.option.idea"),
+                            },
+                            {
+                              value: ServiceRequestTypes.Accessibility,
+                              label: t(
+                                "field.serviceRequestType.option.accessibility"
+                              ),
+                            },
+                            {
+                              value: ServiceRequestTypes.Other,
+                              label: t("field.serviceRequestType.option.other"),
+                            },
+                          ]}
+                        />
+                      )}
+                      {getIsFieldUsed("title") && (
+                        <Input
+                          component={Theme.TextInput}
+                          name="title"
+                          id="title"
+                          labelText={t("field.title.label")}
+                        />
+                      )}
+                      {getIsFieldUsed("description") && (
+                        <Input
+                          component={Theme.TextArea}
+                          name="description"
+                          id="description"
+                          labelText={`${t("field.description.label")}`}
+                          required
+                        />
+                      )}
                     </Theme.FieldGrid>
                   </Theme.LabeledSection>
+                )}
+                {getIsFieldUsed("media") && (
+                  <Theme.LabeledSection>
+                    <Theme.TextH2>
+                      {t("form.section.attachments.title")}
+                    </Theme.TextH2>
+                    <Theme.TextP>
+                      {t("form.section.attachments.description")}
+                    </Theme.TextP>
+                    <FileUploadField
+                      name="media"
+                      id="media"
+                      labelText={t("field.firstName.label")}
+                      addFilesButtonLabel={t("field.media.doAddFiles")}
+                      removeFileButtonLabel={t("field.media.doRemoveFile")}
+                      addFilesButton={Theme.ButtonAddFiles}
+                      removeFileButton={Theme.ButtonRemoveFile}
+                      component={Theme.FileUploadField}
+                    />
+                  </Theme.LabeledSection>
+                )}
+                {getIsFieldUsed("firstName", "lastName", "email") && (
+                  <>
+                    <Theme.Section>
+                      <Theme.Checkbox
+                        name="want-reply"
+                        id="want-reply"
+                        checked={showContactDetailFields}
+                        onChange={handleWantReplyToggle}
+                        labelText={t("form.toggle.wantReply")}
+                      />
+                    </Theme.Section>
+                    {showContactDetailFields && (
+                      <Theme.LabeledSection>
+                        <Theme.TextH2>
+                          {t("form.section.contactDetails.title")}
+                        </Theme.TextH2>
+                        <Theme.FieldGrid>
+                          {getIsFieldUsed("firstName") && (
+                            <Input
+                              component={Theme.TextInput}
+                              name="firstName"
+                              id="firstName"
+                              labelText={t("field.firstName.label")}
+                            />
+                          )}
+                          {getIsFieldUsed("lastName") && (
+                            <Input
+                              component={Theme.TextInput}
+                              name="lastName"
+                              id="lastName"
+                              labelText={t("field.lastName.label")}
+                            />
+                          )}
+                          {getIsFieldUsed("email") && (
+                            <Input
+                              component={Theme.TextInput}
+                              name="email"
+                              id="email"
+                              labelText={t("field.email.label")}
+                            />
+                          )}
+                        </Theme.FieldGrid>
+                      </Theme.LabeledSection>
+                    )}
+                  </>
                 )}
                 {status.isSubmitError && (
                   <Theme.ErrorBox label={t("form.doSendFeedback.error")}>

--- a/src/domain/feedbackForm/defaultInitialValues.ts
+++ b/src/domain/feedbackForm/defaultInitialValues.ts
@@ -1,6 +1,7 @@
 import { ServiceRequestTypes } from "./constants";
+import { FormValues } from "./types";
 
-export default {
+const defaultInitialValues: FormValues = {
   serviceRequestType: ServiceRequestTypes.Other,
   title: null,
   description: "",
@@ -9,3 +10,5 @@ export default {
   lastName: null,
   email: null,
 };
+
+export default defaultInitialValues;

--- a/src/domain/feedbackForm/types.ts
+++ b/src/domain/feedbackForm/types.ts
@@ -19,6 +19,8 @@ export interface FormValues {
   email: string | null;
 }
 
+export type FormFields = keyof FormValues;
+
 export type ButtonAddFilesProps = {
   children: ReactNode;
   onClick: ReactEventHandler<HTMLSpanElement>;


### PR DESCRIPTION
## Description

Allows consumer of component to include or exclude fields on will by using the include/exclude pattern.

By default all fields are included and none are excluded.

When the consumer of the component excludes a field and fails to provide a valid default value for it, a warning is logged in the console.

## Motivation and Context

I decided to allow all exclusions because it wasn't entirely clear which fields should be excluded. We can limit control by hiding the include/exclude interface in the `<FeedbackComponent />` and providing other controls, such as `hideTitle`.

## How Has This Been Tested?

I've added controls for this feature into the playground.

